### PR TITLE
Enforce Type System on SameSite=None cookies to be Secure

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,10 +37,10 @@
   },
   "devDependencies": {
     "@types/mocha": "^5.2.0",
-    "@types/node": "^12.11.1",
+    "@types/node": "^12.12.24",
     "browserify": "^16.2.2",
-    "http-server": "^0.11.1",
-    "mocha": "^6.2.1",
-    "typescript": "^3.6.4"
+    "http-server": "^0.12.1",
+    "mocha": "^7.0.0",
+    "typescript": "^3.7.4"
   }
 }

--- a/src/CookieAttributes.ts
+++ b/src/CookieAttributes.ts
@@ -1,27 +1,27 @@
-export type CookieAttributes = BaseCookieAttributes & SameSiteCookieAttributes
+export type CookieAttributes = BaseCookieAttributes & SameSiteCookieAttributes;
 
-export interface BaseCookieAttributes {
+interface BaseCookieAttributes {
     /**
      * A number will be interpreted as days from time of creation
      */
-    expires?: Date | number
+    expires?: Date | number;
 
     /**
      * Hosts to which the cookie will be sent
      */
-    domain?: string
+    domain?: string;
 
     /**
      * The cookie will only be included in an HTTP request if the request
      * path matches (or is a subdirectory of) the cookie's path attribute.
      */
-    path?: string
+    path?: string;
 
     /**
      * If enabled, the cookie will only be included in an HTTP request
      * if it is transmitted over a secure channel (typically HTTP over TLS).
      */
-    secure?: boolean
+    secure?: boolean;
 }
 
 /**
@@ -29,7 +29,7 @@ export interface BaseCookieAttributes {
  * cookie is from. This provides some protection against cross-site request
  * forgery attacks (CSRF).
  */
-export type SameSiteCookieAttributes = LaxStrictSameSiteCookieAttributes | NoneSameSiteCookieAttributes
+type SameSiteCookieAttributes = LaxStrictSameSiteCookieAttributes | NoneSameSiteCookieAttributes;
 
 /**
  * The strict mode witholds the cookie from any kind of cross-site usage
@@ -38,14 +38,14 @@ export type SameSiteCookieAttributes = LaxStrictSameSiteCookieAttributes | NoneS
  * sends it whenever a user navigates safely from an external site (e.g.
  * by following a link).
  */
-export interface LaxStrictSameSiteCookieAttributes {
-    sameSite?: 'strict' | 'lax'
+interface LaxStrictSameSiteCookieAttributes {
+    sameSite?: 'strict' | 'lax';
 }
 
 /**
  * Cookies with `SameSite=None` must also specify 'Secure'
  */
-export interface NoneSameSiteCookieAttributes {
-    sameSite: 'none'
-    secure: true
+interface NoneSameSiteCookieAttributes {
+    sameSite: 'none';
+    secure: true;
 }

--- a/src/CookieAttributes.ts
+++ b/src/CookieAttributes.ts
@@ -24,21 +24,20 @@ interface BaseCookieAttributes {
     secure?: boolean;
 }
 
-/**
- * Only send the cookie if the request originates from the same website the
- * cookie is from. This provides some protection against cross-site request
- * forgery attacks (CSRF).
- */
 type SameSiteCookieAttributes = LaxStrictSameSiteCookieAttributes | NoneSameSiteCookieAttributes;
 
-/**
- * The strict mode witholds the cookie from any kind of cross-site usage
- * (including inbound links from external sites). The lax mode witholds
- * the cookie on cross-domain subrequests (e.g. images or frames), but
- * sends it whenever a user navigates safely from an external site (e.g.
- * by following a link).
- */
 interface LaxStrictSameSiteCookieAttributes {
+    /**
+     * Only send the cookie if the request originates from the same website the
+     * cookie is from. This provides some protection against cross-site request
+     * forgery attacks (CSRF).
+     *
+     * The strict mode witholds the cookie from any kind of cross-site usage
+     * (including inbound links from external sites). The lax mode witholds
+     * the cookie on cross-domain subrequests (e.g. images or frames), but
+     * sends it whenever a user navigates safely from an external site (e.g.
+     * by following a link).
+     */
     sameSite?: 'strict' | 'lax';
 }
 

--- a/src/CookieAttributes.ts
+++ b/src/CookieAttributes.ts
@@ -1,36 +1,51 @@
-export interface CookieAttributes {
+export type CookieAttributes = BaseCookieAttributes & SameSiteCookieAttributes
+
+export interface BaseCookieAttributes {
     /**
      * A number will be interpreted as days from time of creation
      */
-    expires?: Date | number;
+    expires?: Date | number
 
     /**
      * Hosts to which the cookie will be sent
      */
-    domain?: string;
+    domain?: string
 
     /**
      * The cookie will only be included in an HTTP request if the request
      * path matches (or is a subdirectory of) the cookie's path attribute.
      */
-    path?: string;
+    path?: string
 
     /**
      * If enabled, the cookie will only be included in an HTTP request
      * if it is transmitted over a secure channel (typically HTTP over TLS).
      */
-    secure?: boolean;
+    secure?: boolean
+}
 
-    /**
-     * Only send the cookie if the request originates from the same website the
-     * cookie is from. This provides some protection against cross-site request
-     * forgery attacks (CSRF).
-     *
-     * The strict mode witholds the cookie from any kind of cross-site usage
-     * (including inbound links from external sites). The lax mode witholds
-     * the cookie on cross-domain subrequests (e.g. images or frames), but
-     * sends it whenever a user navigates safely from an external site (e.g.
-     * by following a link).
-     */
-    sameSite?: 'strict' | 'lax' | 'none';
+/**
+ * Only send the cookie if the request originates from the same website the
+ * cookie is from. This provides some protection against cross-site request
+ * forgery attacks (CSRF).
+ */
+export type SameSiteCookieAttributes = LaxStrictSameSiteCookieAttributes | NoneSameSiteCookieAttributes
+
+/**
+ * The strict mode witholds the cookie from any kind of cross-site usage
+ * (including inbound links from external sites). The lax mode witholds
+ * the cookie on cross-domain subrequests (e.g. images or frames), but
+ * sends it whenever a user navigates safely from an external site (e.g.
+ * by following a link).
+ */
+export interface LaxStrictSameSiteCookieAttributes {
+    sameSite?: 'strict' | 'lax'
+}
+
+/**
+ * Cookies with `SameSite=None` must also specify 'Secure'
+ */
+export interface NoneSameSiteCookieAttributes {
+    sameSite: 'none'
+    secure: true
 }

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -150,7 +150,7 @@ describe('encode', function () {
         assert.strictEqual(lax, 'c=v; SameSite=lax');
 
         let none = Cookies.encode('c', 'v', { sameSite: 'none', secure: true });
-        assert.strictEqual(none, 'c=v; SameSite=none; Secure');
+        assert.strictEqual(none, 'c=v; Secure; SameSite=none');
     });
 
     it('should not set undefined attribute values', function () {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -149,8 +149,8 @@ describe('encode', function () {
         let lax = Cookies.encode('c', 'v', { sameSite: 'lax' });
         assert.strictEqual(lax, 'c=v; SameSite=lax');
 
-        let none = Cookies.encode('c', 'v', { sameSite: 'none' });
-        assert.strictEqual(none, 'c=v; SameSite=none');
+        let none = Cookies.encode('c', 'v', { sameSite: 'none', secure: true });
+        assert.strictEqual(none, 'c=v; SameSite=none; Secure');
     });
 
     it('should not set undefined attribute values', function () {


### PR DESCRIPTION
All `SameSite=None` cookies must be `Secure`.