### PR TITLE
Export Cookie Attribute types

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "src/*.js",
     "src/*.d.ts"
   ],
-  "main": "src/es-cookie.js",
-  "types": "./src/es-cookie.d.ts",
+  "main": "src/index.js",
+  "types": "./src/index.d.ts",
   "keywords": [
     "cookies",
     "typescript",

--- a/src/CookieAttributes.ts
+++ b/src/CookieAttributes.ts
@@ -1,6 +1,6 @@
 export type CookieAttributes = BaseCookieAttributes & SameSiteCookieAttributes;
 
-interface BaseCookieAttributes {
+export interface BaseCookieAttributes {
     /**
      * A number will be interpreted as days from time of creation
      */
@@ -24,9 +24,9 @@ interface BaseCookieAttributes {
     secure?: boolean;
 }
 
-type SameSiteCookieAttributes = LaxStrictSameSiteCookieAttributes | NoneSameSiteCookieAttributes;
+export type SameSiteCookieAttributes = LaxStrictSameSiteCookieAttributes | NoneSameSiteCookieAttributes;
 
-interface LaxStrictSameSiteCookieAttributes {
+export interface LaxStrictSameSiteCookieAttributes {
     /**
      * Only send the cookie if the request originates from the same website the
      * cookie is from. This provides some protection against cross-site request
@@ -44,7 +44,7 @@ interface LaxStrictSameSiteCookieAttributes {
 /**
  * Cookies with `SameSite=None` must also specify 'Secure'
  */
-interface NoneSameSiteCookieAttributes {
+export interface NoneSameSiteCookieAttributes {
     sameSite: 'none';
     secure: true;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,2 @@
+export * from './CookieAttributes';
+export * from './es-cookie';


### PR DESCRIPTION
Usage: 

- `Allow developers of other packages to restrict users to a subset of CookieAttributes`

- `Allow type guards for users of this package`

(I'm being annoying 😅)