### PR TITLE
Support expires values larger than the maximum date

### DIFF
--- a/src/es-cookie.ts
+++ b/src/es-cookie.ts
@@ -18,9 +18,8 @@ function stringifyAttribute(name: string, value: string | boolean | undefined): 
 
 function stringifyAttributes(attributes: CookieAttributes): string {
     if (typeof attributes.expires === 'number') {
-        let expires = new Date();
-        expires.setMilliseconds(expires.getMilliseconds() + attributes.expires * 864e+5);
-        attributes.expires = expires;
+        const milliseconds = Math.min(Date.now() + attributes.expires * 864e+5, 864e+13);
+        attributes.expires = new Date(milliseconds);
     }
 
     return stringifyAttribute('Expires', attributes.expires ? attributes.expires.toUTCString() : '')

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -97,6 +97,12 @@ describe('encode', function () {
         assert.strictEqual(actual, 'c=v; Expires=' + twentyOneDaysFromNow.toUTCString());
     });
 
+    it('should work with expires above the maximum date', function () {
+        let maximum = new Date(864e+13);
+        let actual = Cookies.encode('c', 'v', { expires: 864e+14 });
+        assert.strictEqual(actual, 'c=v; Expires=' + maximum.toUTCString());
+    });
+
     it('should work with expires as fraction of a day', function () {
         let getAttributeValue = function (createdCookie: string, attributeName: string) {
             let pairs = createdCookie.split('; ');


### PR DESCRIPTION
`Expires` should work even when it is above **the maximum date**